### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,12 @@
 
 Vagrant.configure("2") do |config|  
+  
+  config.vm.define vm_name="mysql" do |mysql|
+    mysql.vm.box = "aakulov/mysql64"
+    mysql.vm.hostname = vm_name
+    mysql.vm.network "private_network", ip: "192.168.101.100"
+  end
+  
   (1..2).each do |i|
     config.vm.define "web0#{i}" do |web|
       web.vm.box = "aakulov/nginx64"
@@ -8,10 +15,6 @@ Vagrant.configure("2") do |config|
     end
   end
   
-  config.vm.define vm_name="mysql" do |mysql|
-    mysql.vm.box = "aakulov/mysql64"
-    mysql.vm.hostname = vm_name
-    mysql.vm.network "private_network", ip: "192.168.102.101"
-  end
+
 
 end


### PR DESCRIPTION
Vagrantfile is read top to bottom

so if we put the DB first, it will be created first

Vagrant will create a private switch for each network, so having web and db on separate network will force virtualbox to create 2 network/virtual switches

so less is more
